### PR TITLE
Update README and minor update to config and setup

### DIFF
--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -42,6 +42,9 @@ module SidekiqPrometheus
     # Orverride the default Prometheus Metric Registry
     # @return [Prometheus::Client::Registry]
     attr_writer :registry
+
+    # @private
+    attr_writer :setup_complete
   end
 
   self.gc_metrics_enabled = true
@@ -117,17 +120,19 @@ module SidekiqPrometheus
   # Prometheus client metric registry
   # @return [Prometheus::Client::Registry]
   def registry
-    @registry ||= client.registry
+    @registry ||= client::Registry.new
   end
 
   ##
   # register metrics and instrument sidekiq
   def setup
+    return false if @setup_complete
     SidekiqPrometheus::Metrics.register_sidekiq_job_metrics
     SidekiqPrometheus::Metrics.register_sidekiq_gc_metric if gc_metrics_enabled?
     SidekiqPrometheus::Metrics.register_sidekiq_worker_gc_metrics if gc_metrics_enabled? && periodic_metrics_enabled?
     SidekiqPrometheus::Metrics.register_sidekiq_global_metrics if global_metrics_enabled? && periodic_metrics_enabled?
     sidekiq_setup
+    self.setup_complete = true
   end
 
   ##

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -63,7 +63,7 @@ module SidekiqPrometheus
   end
 
   ##
-  # Configure SidekiqPrometheus
+  # Configure SidekiqPrometheus and setup for reporting
   # @example
   #   SidekiqPrometheus.configure do |config|
   #     config.base_labels = { service: 'images_api' }
@@ -72,16 +72,11 @@ module SidekiqPrometheus
   #   end
   def configure
     yield self
-  end
-
-  ##
-  # Configure and call setup immediately after
-  def configure!
-    yield self
     setup
   end
 
-  ##
+  alias configure! configure
+
   # Helper method for +gc_metrics_enabled+ configuration setting
   # @return [Boolean] defaults to true
   def gc_metrics_enabled?

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -163,12 +163,6 @@ module SidekiqPrometheus
       )
     end
   end
-
-  private
-
-  def metrics
-    SidekiqPrometheus::Metrics
-  end
 end
 
 require 'sidekiq_prometheus/job_metrics'

--- a/spec/sidekiq_prometheus_spec.rb
+++ b/spec/sidekiq_prometheus_spec.rb
@@ -28,10 +28,14 @@ RSpec.describe SidekiqPrometheus do
       end
 
       expect(described_class.base_labels).to eq base
+    end
 
-      described_class.configure do |c|
-        c.base_labels = nil
-      end
+    it 'calls setup' do
+      allow(described_class).to receive(:setup)
+
+      described_class.configure {}
+
+      expect(described_class).to have_received(:setup)
     end
   end
 


### PR DESCRIPTION
* adds instructions in README on how to set a custom registry
* Reorganizes the README a little to make it clearer to follow
* Removes `configure!` and always call `setup` from `configure`
* Add alias for `configure!` -> `configure`
* ensures setup is only called once

Addresses #1 