### PR TITLE
Custom Metrics: implement as configuration and add docs

### DIFF
--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -20,6 +20,21 @@ module SidekiqPrometheus
     # @return [Hash] Custom labels applied to specific metrics
     attr_accessor :custom_labels
 
+    # @return [Array] Custom metrics that will be registered on setup.
+    # @example
+    #   [
+    #     {
+    #       name: :metric_name,
+    #       type: :prometheus_metric_type,
+    #       docstring: 'Description of the metric',
+    #       base_labels : { label: 'value' },
+    #     }
+    #   ]
+    # @note Each element of the array is a hash and must have the required keys: `:name`, `:type`, and `:docstring`.
+    #   The values for `:name` and `:type` should be symbols and `:docstring` should be a string.
+    #   `base_labels` is optional and, if used, must be a hash of labels that will be included on every instance of this metric.
+    attr_accessor :custom_metrics
+
     # @return [Boolean] Setting to control enabling/disabling GC metrics. Default: true
     attr_accessor :gc_metrics_enabled
 
@@ -53,6 +68,7 @@ module SidekiqPrometheus
   self.periodic_reporting_interval = 30
   self.metrics_port = 9359
   self.custom_labels = {}
+  self.custom_metrics = []
 
   module_function
 
@@ -119,6 +135,20 @@ module SidekiqPrometheus
   end
 
   ##
+  # Register custom metrics
+  # Internal method called by +setup+. This method should not be called from application code in most cases.
+  def register_custom_metrics
+    return if custom_metrics.empty?
+
+    expected_keys = %i[name type docstring].sort
+    if custom_metrics.all? { |m| (m.keys.sort & expected_keys) == expected_keys }
+      SidekiqPrometheus::Metrics.register_metrics(custom_metrics)
+    else
+      Sidekiq.logger.warn('[SidekiqPrometheus] Skipping custom metrics. Hash does not define required keys')
+    end
+  end
+
+  ##
   # register metrics and instrument sidekiq
   def setup
     return false if @setup_complete
@@ -126,7 +156,10 @@ module SidekiqPrometheus
     SidekiqPrometheus::Metrics.register_sidekiq_gc_metric if gc_metrics_enabled?
     SidekiqPrometheus::Metrics.register_sidekiq_worker_gc_metrics if gc_metrics_enabled? && periodic_metrics_enabled?
     SidekiqPrometheus::Metrics.register_sidekiq_global_metrics if global_metrics_enabled? && periodic_metrics_enabled?
+    register_custom_metrics
+
     sidekiq_setup
+
     self.setup_complete = true
   end
 

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -140,12 +140,9 @@ module SidekiqPrometheus
   def register_custom_metrics
     return if custom_metrics.empty?
 
-    expected_keys = %i[name type docstring].sort
-    if custom_metrics.all? { |m| (m.keys.sort & expected_keys) == expected_keys }
-      SidekiqPrometheus::Metrics.register_metrics(custom_metrics)
-    else
-      Sidekiq.logger.warn('[SidekiqPrometheus] Skipping custom metrics. Hash does not define required keys')
-    end
+    raise SidekiqPrometheus::Error, 'custom_metrics is not an array.' unless custom_metrics.is_a?(Array)
+
+    SidekiqPrometheus::Metrics.register_metrics(custom_metrics)
   end
 
   ##
@@ -197,6 +194,8 @@ module SidekiqPrometheus
     end
   end
 end
+
+class SidekiqPrometheus::Error < StandardError; end
 
 require 'sidekiq_prometheus/job_metrics'
 require 'sidekiq_prometheus/metrics'

--- a/spec/sidekiq_prometheus_spec.rb
+++ b/spec/sidekiq_prometheus_spec.rb
@@ -63,6 +63,52 @@ RSpec.describe SidekiqPrometheus do
     end
   end
 
+  describe '.register_custom_metrics' do
+    let(:logger) { double 'logger', warn: nil }
+
+    before do
+      Sidekiq.logger = logger
+    end
+
+    after do
+      described_class.custom_metrics = []
+      Sidekiq.logger = Logger.new('/dev/null')
+    end
+
+    it 'does nothing if no custom metrics are defined' do
+      allow(SidekiqPrometheus::Metrics).to receive(:register_metrics)
+
+      expect(described_class.custom_metrics).to eq []
+      expect(described_class.register_custom_metrics).to be nil
+      expect(SidekiqPrometheus::Metrics).not_to have_received(:register_metrics)
+    end
+
+    it 'skips registering and logs a warning if hash keys are missing' do
+      allow(SidekiqPrometheus::Metrics).to receive(:register_metrics)
+
+      described_class.custom_metrics = [{ name: :foo, type: :gauge }]
+      described_class.register_custom_metrics
+
+      expect(logger).to have_received(:warn).with('[SidekiqPrometheus] Skipping custom metrics. Hash does not define required keys')
+    end
+
+    it 'registers the custom metrics' do
+      custom = [
+        {
+          name: :rpm,
+          type: :gauge,
+          docstring: 'revolutions per minute',
+        },
+      ]
+
+      described_class.custom_metrics = custom
+      described_class.register_custom_metrics
+
+      expect(logger).not_to have_received(:warn)
+      expect(described_class.get(:rpm)).to be_kind_of(Prometheus::Client::Gauge)
+    end
+  end
+
   describe '.setup' do
     it 'registers metrics and instruments sidekiq for prometheus' do
       allow(Object).to receive(:const_defined?).with('Sidekiq::Enterprise').and_return(true)
@@ -76,6 +122,17 @@ RSpec.describe SidekiqPrometheus do
       events = Sidekiq.options[:lifecycle_events]
       expect(events[:startup].first).to be_kind_of(Proc)
       expect(events[:shutdown].first).to be_kind_of(Proc)
+    end
+
+    it 'registers custom metrics' do
+      custom = [{ name: :rpm, type: :gauge, docstring: 'rpm' }]
+
+      described_class.custom_metrics = custom
+      described_class.setup
+
+      expect(described_class.get(:rpm)).to be_kind_of(Prometheus::Client::Gauge)
+
+      described_class.custom_metrics = []
     end
 
     it 'can only be called once' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,5 @@ def silence
   $stderr = original_stderr
   $stdout = original_stdout
 end
+
+Sidekiq.logger = Logger.new('/dev/null')


### PR DESCRIPTION
### Summary

* add SidekiqPrometheus.custom_metrics accessor that can be used in a configure block to define and register custom metrics
* does some basic validation of the custom metrics
* update the README with instructions on how to configure, register, and use custom metrics.

Closes #2 