### PR TITLE
Add support for prometheus-client 0.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /tmp/
 .rspec_status
 Gemfile.lock
+/.idea/

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -14,10 +14,10 @@ end
 
 module SidekiqPrometheus
   class << self
-    # @return [Hash] Base labels applied to every registered metric
-    attr_accessor :base_labels
+    # @return [Hash] Preset labels applied to every registered metric
+    attr_accessor :preset_labels
 
-    # @return [Hash] Custom labels applied to specific metrics
+    # @return [Hash{Symbol => Array<Symbol>}] Custom labels applied to specific metrics
     attr_accessor :custom_labels
 
     # @return [Array] Custom metrics that will be registered on setup.
@@ -27,12 +27,12 @@ module SidekiqPrometheus
     #       name: :metric_name,
     #       type: :prometheus_metric_type,
     #       docstring: 'Description of the metric',
-    #       base_labels : { label: 'value' },
+    #       preset_labels : { label: 'value' },
     #     }
     #   ]
     # @note Each element of the array is a hash and must have the required keys: `:name`, `:type`, and `:docstring`.
     #   The values for `:name` and `:type` should be symbols and `:docstring` should be a string.
-    #   `base_labels` is optional and, if used, must be a hash of labels that will be included on every instance of this metric.
+    #   `preset_labels` is optional and, if used, must be a hash of labels that will be included on every instance of this metric.
     attr_accessor :custom_metrics
 
     # @return [Boolean] Setting to control enabling/disabling GC metrics. Default: true
@@ -82,8 +82,8 @@ module SidekiqPrometheus
   # Configure SidekiqPrometheus and setup for reporting
   # @example
   #   SidekiqPrometheus.configure do |config|
-  #     config.base_labels = { service: 'images_api' }
-  #     config.custom_labels = { sidekiq_job_count: { object_klass: nil } }
+  #     config.preset_labels = { service: 'images_api' }
+  #     config.custom_labels = { sidekiq_job_count: [:custom_label_1, :custom_label_2] } }
   #     config.gc_metrics_enabled = true
   #   end
   def configure

--- a/lib/sidekiq_prometheus/job_metrics.rb
+++ b/lib/sidekiq_prometheus/job_metrics.rb
@@ -15,20 +15,20 @@ class SidekiqPrometheus::JobMetrics
       # In case the labels have changed after the worker perform method has been called
       labels.merge!(custom_labels(worker))
 
-      registry[:sidekiq_job_duration].observe(labels, duration)
-      registry[:sidekiq_job_success].increment(labels)
+      registry[:sidekiq_job_duration].observe(duration, labels: labels)
+      registry[:sidekiq_job_success].increment(labels: labels)
 
       if SidekiqPrometheus.gc_metrics_enabled?
         allocated = GC.stat(:total_allocated_objects) - before
-        registry[:sidekiq_job_allocated_objects].observe(labels, allocated)
+        registry[:sidekiq_job_allocated_objects].observe(allocated, labels: labels)
       end
 
       result
     rescue StandardError => e
-      registry[:sidekiq_job_failed].increment(labels)
+      registry[:sidekiq_job_failed].increment(labels: labels)
       raise e
     ensure
-      registry[:sidekiq_job_count].increment(labels)
+      registry[:sidekiq_job_count].increment(labels: labels)
     end
   end
 

--- a/sidekiq_prometheus.gemspec
+++ b/sidekiq_prometheus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.58.0'
 
-  spec.add_runtime_dependency 'prometheus-client', '~> 0.8.0'
+  spec.add_runtime_dependency 'prometheus-client', '~> 0.10.0'
   spec.add_runtime_dependency 'rack'
   spec.add_runtime_dependency 'sidekiq', '~> 5.1'
 end

--- a/spec/sidekiq_prometheus/job_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/job_metrics_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
       expect(registry).to have_received(:get).with(:sidekiq_job_success)
       expect(registry).to have_received(:get).with(:sidekiq_job_allocated_objects)
 
-      expect(metric).to have_received(:increment).twice.with(labels)
-      expect(metric).to have_received(:observe).twice.with(labels, kind_of(Numeric))
+      expect(metric).to have_received(:increment).twice.with(labels: labels)
+      expect(metric).to have_received(:observe).twice.with(kind_of(Numeric), labels: labels)
     end
 
     it 'returns the result from the yielded block' do
@@ -57,7 +57,7 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
       expect(registry).not_to have_received(:get).with(:sidekiq_job_duration)
       expect(registry).not_to have_received(:get).with(:sidekiq_job_success)
 
-      expect(metric).to have_received(:increment).twice.with(labels)
+      expect(metric).to have_received(:increment).twice.with(labels: labels)
       expect(metric).not_to have_received(:observe)
     end
   end

--- a/spec/sidekiq_prometheus/periodic_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/periodic_metrics_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe SidekiqPrometheus::PeriodicMetrics do
 
       reporter.report_gc_metrics
 
-      expect(metric).to have_received(:increment).with({}, kind_of(Numeric)).exactly(described_class::GC_STATS[:counters].size).times
+      expect(metric).to have_received(:increment).with(by: kind_of(Numeric), labels: {}).exactly(described_class::GC_STATS[:counters].size).times
       # plus one because rss
-      expect(metric).to have_received(:set).with({}, kind_of(Numeric)).exactly(described_class::GC_STATS[:gauges].size + 1).times
+      expect(metric).to have_received(:set).with(kind_of(Numeric), labels: {}).exactly(described_class::GC_STATS[:gauges].size + 1).times
     end
   end
 
@@ -83,12 +83,12 @@ RSpec.describe SidekiqPrometheus::PeriodicMetrics do
         expect(sidekiq_stats).to have_received(stat)
       end
 
-      expect(metric).to have_received(:set).with({}, num).exactly(described_class::GLOBAL_STATS.size).times
+      expect(metric).to have_received(:set).with(num, labels: {}).exactly(described_class::GLOBAL_STATS.size).times
 
-      expect(metric).to have_received(:set).with({ queue: queue.name }, queue.size)
-      expect(metric).to have_received(:observe).with({ queue: queue.name }, queue.latency)
-      expect(metric).to have_received(:set).with({ queue: another_queue.name }, another_queue.size)
-      expect(metric).to have_received(:observe).with({ queue: another_queue.name }, another_queue.latency)
+      expect(metric).to have_received(:set).with(queue.size, labels: { queue: queue.name })
+      expect(metric).to have_received(:observe).with(queue.latency, labels: { queue: queue.name })
+      expect(metric).to have_received(:set).with(another_queue.size, labels: { queue: another_queue.name })
+      expect(metric).to have_received(:observe).with(another_queue.latency, labels: { queue: another_queue.name })
     end
   end
 
@@ -116,13 +116,13 @@ RSpec.describe SidekiqPrometheus::PeriodicMetrics do
 
       reporter.report_redis_metrics
 
-      expect(metric).to have_received(:set).with({}, 1)
-      expect(metric).to have_received(:set).with({}, 1024)
-      expect(metric).to have_received(:set).with({}, 2048)
-      expect(metric).to have_received(:set).with({ database: 'db0' }, 1)
-      expect(metric).to have_received(:set).with({ database: 'db0' }, 0)
-      expect(metric).to have_received(:set).with({ database: 'db1' }, 100)
-      expect(metric).to have_received(:set).with({ database: 'db1' }, 10)
+      expect(metric).to have_received(:set).with(1, labels: {})
+      expect(metric).to have_received(:set).with(1024, labels: {})
+      expect(metric).to have_received(:set).with(2048, labels: {})
+      expect(metric).to have_received(:set).with(1, labels: { database: 'db0' })
+      expect(metric).to have_received(:set).with(0, labels: { database: 'db0' })
+      expect(metric).to have_received(:set).with(100, labels: { database: 'db1' })
+      expect(metric).to have_received(:set).with(10, labels: { database: 'db1' })
     end
   end
 end

--- a/spec/sidekiq_prometheus_spec.rb
+++ b/spec/sidekiq_prometheus_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe SidekiqPrometheus do
     it 'configures' do
       base = { label: 'label' }
       described_class.configure do |c|
-        c.base_labels = base
+        c.preset_labels = base
       end
 
-      expect(described_class.base_labels).to eq base
+      expect(described_class.preset_labels).to eq base
     end
 
     it 'calls setup' do


### PR DESCRIPTION
## Summary of the changes - 

- Updated prometheus-client to `0.10.0`
- Changed `metrics.rb` to comply with newer changes
- Refactored `base_labels` to `preset_labels`
- Added keys from the `preset_labels` to `labels` while registering new metrics
- Added keys from `custom_labels` as part of `labels` while registering new metrics
- Updated `README`

