### PR TITLE
metrics_host

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ end
 * `global_metrics_enabled`: Boolean that determines whether to report global metrics from the PeriodicMetrics reporter. When `true` this will report on a number of stats from the Sidekiq API for the cluster. This requires Sidekiq::Enterprise as the reporter uses the leader election functionality to ensure that only one worker per cluster is reporting metrics.
 * `periodic_metrics_enabled`: Boolean that determines whether to run the periodic metrics reporter. `PeriodicMetrics` runs a separate thread that reports on global metrics (if enabled) as well worker GC stats (if enabled). It reports metrics on the interval defined by `periodic_reporting_interval`. Defaults to `true`.
 * `periodic_reporting_interval`: interval in seconds for reporting periodic metrics. Default: `30`
+* `metrics_host`: Host on which the rack server will listen. Defaults to
+  `localhost`
 * `metrics_port`: Port on which the rack server will listen. Defaults to `9359`
 * `registry`: An instance of `Prometheus::Client::Registry`. If you have a registry with defined metrics you can use this option to pass in your registry.
 

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -47,6 +47,9 @@ module SidekiqPrometheus
     # @return [Integer] Interval in seconds to record metrics. Default: 30
     attr_accessor :periodic_reporting_interval
 
+    # @return [String] Host on which the metrics server will listen. Default: localhost
+    attr_accessor :metrics_host
+
     # @return [Integer] Port on which the metrics server will listen. Default: 9357
     attr_accessor :metrics_port
 
@@ -66,6 +69,7 @@ module SidekiqPrometheus
   self.periodic_metrics_enabled = true
   self.global_metrics_enabled = true
   self.periodic_reporting_interval = 30
+  self.metrics_host = 'localhost'
   self.metrics_port = 9359
   self.custom_labels = {}
   self.custom_metrics = []
@@ -179,7 +183,8 @@ module SidekiqPrometheus
 
   ##
   # Start a new Prometheus exporter in a new thread.
-  # Will listen on SidekiqPrometheus.metrics_port
+  # Will listen on SidekiqPrometheus.metrics_host and
+  # SidekiqPrometheus.metrics_port
   def metrics_server
     @_metrics_server ||= Thread.new do
       Rack::Handler::WEBrick.run(
@@ -188,7 +193,7 @@ module SidekiqPrometheus
           run ->(_) { [301, { 'Location' => '/metrics' }, []] }
         },
         Port: SidekiqPrometheus.metrics_port,
-        BindAddress: 'localhost',
+        BindAddress: SidekiqPrometheus.metrics_host,
       )
     end
   end

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -193,7 +193,7 @@ module SidekiqPrometheus
           run ->(_) { [301, { 'Location' => '/metrics' }, []] }
         },
         Port: SidekiqPrometheus.metrics_port,
-        BindAddress: SidekiqPrometheus.metrics_host,
+        Host: SidekiqPrometheus.metrics_host,
       )
     end
   end

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -188,7 +188,7 @@ module SidekiqPrometheus
           run ->(_) { [301, { 'Location' => '/metrics' }, []] }
         },
         Port: SidekiqPrometheus.metrics_port,
-        BindAddress: '127.0.0.1',
+        BindAddress: 'localhost',
       )
     end
   end

--- a/spec/sidekiq_prometheus_spec.rb
+++ b/spec/sidekiq_prometheus_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe SidekiqPrometheus do
 
         sleep 0.5
 
-        http = Net::HTTP.new('localhost', SidekiqPrometheus.metrics_port)
+        http = Net::HTTP.new(SidekiqPrometheus.metrics_host, SidekiqPrometheus.metrics_port)
         res = http.request(Net::HTTP::Get.new('/metrics'))
 
         expect(res.code).to eq '200'

--- a/spec/sidekiq_prometheus_spec.rb
+++ b/spec/sidekiq_prometheus_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe SidekiqPrometheus do
 
         sleep 0.5
 
-        http = Net::HTTP.new('127.0.0.1', SidekiqPrometheus.metrics_port)
+        http = Net::HTTP.new('localhost', SidekiqPrometheus.metrics_port)
         res = http.request(Net::HTTP::Get.new('/metrics'))
 
         expect(res.code).to eq '200'


### PR DESCRIPTION
Adds `SidekiqPrometheus.metrics_host` which allows configuring the host that `SidekiqPrometheus.metrics_server` listens on. Defaults to `localhost`; as `127.0.0.1` may not always be the system's configured loopback address.