### PR TITLE
Add SidekiqPrometheus.metrics_server_enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ end
 * `global_metrics_enabled`: Boolean that determines whether to report global metrics from the PeriodicMetrics reporter. When `true` this will report on a number of stats from the Sidekiq API for the cluster. This requires Sidekiq::Enterprise as the reporter uses the leader election functionality to ensure that only one worker per cluster is reporting metrics.
 * `periodic_metrics_enabled`: Boolean that determines whether to run the periodic metrics reporter. `PeriodicMetrics` runs a separate thread that reports on global metrics (if enabled) as well worker GC stats (if enabled). It reports metrics on the interval defined by `periodic_reporting_interval`. Defaults to `true`.
 * `periodic_reporting_interval`: interval in seconds for reporting periodic metrics. Default: `30`
+* `metrics_server_enabled`: Boolean that determines whether to run the rack server. Defaults to `true`
 * `metrics_host`: Host on which the rack server will listen. Defaults to
   `localhost`
 * `metrics_port`: Port on which the rack server will listen. Defaults to `9359`
@@ -94,6 +95,7 @@ SidekiqPrometheus.configure do |config|
   config.global_metrics_enabled        = true
   config.periodic_metrics_enabled      = true
   config.periodic_reporting_interval   = 20
+  config.metrics_server_enabled        = true
   config.metrics_port                  = 8675
 end
 ```

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -47,6 +47,9 @@ module SidekiqPrometheus
     # @return [Integer] Interval in seconds to record metrics. Default: 30
     attr_accessor :periodic_reporting_interval
 
+    # @return [Boolean] Setting to control enabling/disabling the metrics server. Default: true
+    attr_accessor :metrics_server_enabled
+
     # @return [String] Host on which the metrics server will listen. Default: localhost
     attr_accessor :metrics_host
 
@@ -69,6 +72,7 @@ module SidekiqPrometheus
   self.periodic_metrics_enabled = true
   self.global_metrics_enabled = true
   self.periodic_reporting_interval = 30
+  self.metrics_server_enabled = true
   self.metrics_host = 'localhost'
   self.metrics_port = 9359
   self.custom_labels = {}
@@ -115,6 +119,13 @@ module SidekiqPrometheus
   # @return [Boolean] defaults to true if +Sidekiq::Enterprise+ is available
   def periodic_metrics_enabled?
     periodic_metrics_enabled
+  end
+
+  ##
+  # Helper method for +metrics_server_enabled+ configuration setting
+  # @return [Boolean] defaults to true
+  def metrics_server_enabled?
+    metrics_server_enabled
   end
 
   ##
@@ -176,8 +187,10 @@ module SidekiqPrometheus
         config.on(:shutdown) { SidekiqPrometheus::PeriodicMetrics.reporter.stop }
       end
 
-      config.on(:startup)  { SidekiqPrometheus.metrics_server }
-      config.on(:shutdown) { SidekiqPrometheus.metrics_server.kill }
+      if metrics_server_enabled?
+        config.on(:startup)  { SidekiqPrometheus.metrics_server }
+        config.on(:shutdown) { SidekiqPrometheus.metrics_server.kill }
+      end
     end
   end
 

--- a/spec/sidekiq_prometheus_spec.rb
+++ b/spec/sidekiq_prometheus_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe SidekiqPrometheus do
     end
   end
 
+  describe '.metrics_server_enabled?' do
+    it 'returns true by default' do
+      expect(described_class.metrics_server_enabled).to be true
+      expect(described_class.metrics_server_enabled?).to be true
+    end
+
+    it 'returns false when metrics_server_enabled == false' do
+      described_class.metrics_server_enabled = false
+      expect(described_class.metrics_server_enabled?).to be false
+    end
+  end
+
   describe '.register_custom_metrics' do
     after do
       described_class.custom_metrics = []


### PR DESCRIPTION
Hi everyone!

This change adds a boolean configuration option called `metrics_server_enabled` which disables starting the metrics server when set to false. The new setting is optional and defaults to true in order to preserve compatibility with all existing users. I've updated the documentation and added tests for the new option.

The reason I need this is because I'd like to integrate this gem into an existing prometheus project that already has a rack server for exporting metrics, making this one superfluous.

Thanks!