### PR TITLE
Add support to ActiveJob sidekiq adapter

### DIFF
--- a/lib/sidekiq_prometheus/job_metrics.rb
+++ b/lib/sidekiq_prometheus/job_metrics.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 class SidekiqPrometheus::JobMetrics
-  def call(worker, _job, queue)
+  def call(worker, job, queue)
     before = GC.stat(:total_allocated_objects) if SidekiqPrometheus.gc_metrics_enabled?
 
-    labels = { class: worker.class.to_s, queue: queue }
+    # If we're using a wrapper class, like ActiveJob, use the "wrapped"
+    # attribute to expose the underlying thing.
+    labels = {
+      class: job['wrapped'] || worker.class.to_s,
+      queue: queue,
+    }
 
     begin
       labels.merge!(custom_labels(worker))


### PR DESCRIPTION
Add support to ActiveJob.

This PR uses the same method Sidekiq uses to add logging, check: [Sidekiq logger.rb file](https://github.com/mperham/sidekiq/blob/3b5ae30c4e5e9e760268243ab5c14664a2f8d236/lib/sidekiq/job_logger.rb#L41)