### PR TITLE
Add an "error_class" label to the sidekiq_job_failed metric

### DIFF
--- a/lib/sidekiq_prometheus/job_metrics.rb
+++ b/lib/sidekiq_prometheus/job_metrics.rb
@@ -30,7 +30,8 @@ class SidekiqPrometheus::JobMetrics
 
       result
     rescue StandardError => e
-      registry[:sidekiq_job_failed].increment(labels: labels)
+      err_label = { :error_class => e.class.to_s }
+      registry[:sidekiq_job_failed].increment(labels: err_label.merge(labels))
       raise e
     ensure
       registry[:sidekiq_job_count].increment(labels: labels)

--- a/lib/sidekiq_prometheus/metrics.rb
+++ b/lib/sidekiq_prometheus/metrics.rb
@@ -64,7 +64,7 @@ module SidekiqPrometheus::Metrics
     { name:      :sidekiq_job_failed,
       type:      :counter,
       docstring: 'Count of failed Sidekiq jobs',
-      labels:    JOB_LABELS, },
+      labels:    JOB_LABELS + [:error_class], },
     { name:      :sidekiq_job_success,
       type:      :counter,
       docstring: 'Count of successful Sidekiq jobs',

--- a/lib/sidekiq_prometheus/version.rb
+++ b/lib/sidekiq_prometheus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPrometheus
-  VERSION = '1.4.0'
+  VERSION = '1.5.0'
 end

--- a/spec/sidekiq_prometheus/job_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/job_metrics_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
   let(:queue) { 'bbq' }
   let(:job) { {} }
   let(:labels) { { class: worker.class.to_s, queue: queue, foo: 'bar' } }
+  let(:failed_labels) { labels.merge(error_class: RuntimeError.to_s) }
 
   after do
     SidekiqPrometheus.registry = SidekiqPrometheus.client.registry
@@ -58,7 +59,8 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
       expect(registry).not_to have_received(:get).with(:sidekiq_job_duration)
       expect(registry).not_to have_received(:get).with(:sidekiq_job_success)
 
-      expect(metric).to have_received(:increment).twice.with(labels: labels)
+      expect(metric).to have_received(:increment).once.with(labels: failed_labels)
+      expect(metric).to have_received(:increment).once.with(labels: labels)
       expect(metric).not_to have_received(:observe)
     end
 


### PR DESCRIPTION
We'd like to be able to segment out our job failure metrics by specific error types. We're currently interested in `Sidekiq::Limiter::OverLimit` errors, but this seems generally useful enough to include as a label on `sidekiq_job_failed` metric.

I believe this is a minor version bump, and Prometheus should be fine with the addition of a label.