### PR TITLE
Add option for silencing metrics server logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ end
 * `periodic_metrics_enabled`: Boolean that determines whether to run the periodic metrics reporter. `PeriodicMetrics` runs a separate thread that reports on global metrics (if enabled) as well worker GC stats (if enabled). It reports metrics on the interval defined by `periodic_reporting_interval`. Defaults to `true`.
 * `periodic_reporting_interval`: interval in seconds for reporting periodic metrics. Default: `30`
 * `metrics_server_enabled`: Boolean that determines whether to run the rack server. Defaults to `true`
+* `metrics_server_logging_enabled`: Boolean that determines if the metrics server will log access logs. Defaults to `true`
 * `metrics_host`: Host on which the rack server will listen. Defaults to
   `localhost`
 * `metrics_port`: Port on which the rack server will listen. Defaults to `9359`

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -140,7 +140,6 @@ module SidekiqPrometheus
     metrics_server_logger_enabled
   end
 
-
   ##
   # Get a metric from the registry
   # @param metric [Symbol] name of metric to fetch
@@ -218,10 +217,8 @@ module SidekiqPrometheus
     }
 
     unless metrics_server_logger_enabled?
-      opts.merge!(
-        Logger: WEBrick::Log.new("/dev/null"),
-        AccessLog: []
-      )
+      opts[:Logger] = WEBrick::Log.new('/dev/null')
+      opts[:AccessLog] = []
     end
 
     @_metrics_server ||= Thread.new do

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -57,6 +57,9 @@ module SidekiqPrometheus
     # @return [Integer] Port on which the metrics server will listen. Default: 9357
     attr_accessor :metrics_port
 
+    # @return [Boolean] When set to false will silence the metric server access logs. Default: true
+    attr_accessor :metrics_server_logger_enabled
+
     # Override the default Prometheus::Client
     # @return [Prometheus::Client]
     attr_writer :client
@@ -76,6 +79,7 @@ module SidekiqPrometheus
   self.metrics_server_enabled = true
   self.metrics_host = 'localhost'
   self.metrics_port = 9359
+  self.metrics_server_logger_enabled = true
   self.custom_labels = {}
   self.custom_metrics = []
 
@@ -128,6 +132,14 @@ module SidekiqPrometheus
   def metrics_server_enabled?
     metrics_server_enabled
   end
+
+  ##
+  # Helper method for +metrics_server_logger_enabled+ configuration setting
+  # @return [Boolean] defaults to true
+  def metrics_server_logger_enabled?
+    metrics_server_logger_enabled
+  end
+
 
   ##
   # Get a metric from the registry
@@ -200,14 +212,25 @@ module SidekiqPrometheus
   # Will listen on SidekiqPrometheus.metrics_host and
   # SidekiqPrometheus.metrics_port
   def metrics_server
+    opts = {
+      Port: SidekiqPrometheus.metrics_port,
+      Host: SidekiqPrometheus.metrics_host,
+    }
+
+    unless metrics_server_logger_enabled?
+      opts.merge!(
+        Logger: WEBrick::Log.new("/dev/null"),
+        AccessLog: []
+      )
+    end
+
     @_metrics_server ||= Thread.new do
       Rack::Handler::WEBrick.run(
         Rack::Builder.new {
           use Prometheus::Middleware::Exporter, registry: SidekiqPrometheus.registry
           run ->(_) { [301, { 'Location' => '/metrics' }, []] }
         },
-        Port: SidekiqPrometheus.metrics_port,
-        Host: SidekiqPrometheus.metrics_host,
+        **opts
       )
     end
   end

--- a/lib/sidekiq_prometheus/version.rb
+++ b/lib/sidekiq_prometheus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPrometheus
-  VERSION = '1.5.0'
+  VERSION = '1.6.0'
 end

--- a/spec/sidekiq_prometheus_spec.rb
+++ b/spec/sidekiq_prometheus_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe SidekiqPrometheus do
     end
   end
 
+  describe '.metrics_server_logger_enabled?' do
+    it 'returns true by default' do
+      expect(described_class.metrics_server_logger_enabled).to be true
+      expect(described_class.metrics_server_logger_enabled?).to be true
+    end
+
+    it 'returns false when metrics_server_logger_enabled == false' do
+      described_class.metrics_server_logger_enabled = false
+      expect(described_class.metrics_server_logger_enabled?).to be false
+    end
+  end
+
   describe '.register_custom_metrics' do
     after do
       described_class.custom_metrics = []


### PR DESCRIPTION
* adds new option `metrics_server_logging_enabled` that defaults to true
* when set to `false` will silence the WEBrick access logging
