### PR TITLE
Fix typo in readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ end
 * `periodic_metrics_enabled`: Boolean that determines whether to run the periodic metrics reporter. `PeriodicMetrics` runs a separate thread that reports on global metrics (if enabled) as well worker GC stats (if enabled). It reports metrics on the interval defined by `periodic_reporting_interval`. Defaults to `true`.
 * `periodic_reporting_interval`: interval in seconds for reporting periodic metrics. Default: `30`
 * `metrics_server_enabled`: Boolean that determines whether to run the rack server. Defaults to `true`
-* `metrics_server_logging_enabled`: Boolean that determines if the metrics server will log access logs. Defaults to `true`
+* `metrics_server_logger_enabled`: Boolean that determines if the metrics server will log access logs. Defaults to `true`
 * `metrics_host`: Host on which the rack server will listen. Defaults to
   `localhost`
 * `metrics_port`: Port on which the rack server will listen. Defaults to `9359`


### PR DESCRIPTION
The actual attribute is called `metrics_server_logger_enabled` instead of `metrics_server_logging_enabled`.