### PR TITLE
handle rate limiting exceptions distinctly from other exceptions

### DIFF
--- a/lib/sidekiq_prometheus/job_metrics.rb
+++ b/lib/sidekiq_prometheus/job_metrics.rb
@@ -30,8 +30,13 @@ class SidekiqPrometheus::JobMetrics
 
       result
     rescue StandardError => e
-      err_label = { :error_class => e.class.to_s }
-      registry[:sidekiq_job_failed].increment(labels: err_label.merge(labels))
+      if e.class.to_s == "Sidekiq::Limiter::OverLimit"
+        registry[:sidekiq_job_over_limit].increment(labels: labels)
+      else
+        err_label = { :error_class => e.class.to_s }
+        registry[:sidekiq_job_failed].increment(labels: err_label.merge(labels))
+      end
+
       raise e
     ensure
       registry[:sidekiq_job_count].increment(labels: labels)

--- a/lib/sidekiq_prometheus/job_metrics.rb
+++ b/lib/sidekiq_prometheus/job_metrics.rb
@@ -30,7 +30,7 @@ class SidekiqPrometheus::JobMetrics
 
       result
     rescue StandardError => e
-      if e.class.to_s == "Sidekiq::Limiter::OverLimit"
+      if e.class.to_s == 'Sidekiq::Limiter::OverLimit'
         registry[:sidekiq_job_over_limit].increment(labels: labels)
       else
         err_label = { :error_class => e.class.to_s }

--- a/lib/sidekiq_prometheus/metrics.rb
+++ b/lib/sidekiq_prometheus/metrics.rb
@@ -69,6 +69,10 @@ module SidekiqPrometheus::Metrics
       type:      :counter,
       docstring: 'Count of successful Sidekiq jobs',
       labels:    JOB_LABELS, },
+    { name:      :sidekiq_job_over_limit,
+      type:      :counter,
+      docstring: 'Count of over limit Sidekiq jobs',
+      labels:    JOB_LABELS, },
   ].freeze
   SIDEKIQ_GC_METRIC = {
     name:      :sidekiq_job_allocated_objects,

--- a/spec/sidekiq_prometheus/job_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/job_metrics_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
     end
   end
 
-class Sidekiq::Limiter::OverLimit < StandardError; end
+  class Sidekiq::Limiter::OverLimit < StandardError; end
 
   let(:middleware) { described_class.new }
   let(:registry) { instance_double Prometheus::Client::Registry }

--- a/spec/sidekiq_prometheus/job_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/job_metrics_spec.rb
@@ -9,12 +9,7 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
     end
   end
 
-  module Sidekiq
-    module Limiter
-      class OverLimit < StandardError
-      end
-    end
-  end
+class Sidekiq::Limiter::OverLimit < StandardError; end
 
   let(:middleware) { described_class.new }
   let(:registry) { instance_double Prometheus::Client::Registry }

--- a/spec/sidekiq_prometheus/job_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/job_metrics_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe SidekiqPrometheus::JobMetrics do
     end
   end
 
-  class Sidekiq::Limiter::OverLimit < StandardError; end
+  module Sidekiq::Limiter
+    class OverLimit < StandardError
+    end
+  end
 
   let(:middleware) { described_class.new }
   let(:registry) { instance_double Prometheus::Client::Registry }


### PR DESCRIPTION
Sidekiq enterprise rate limiting raises a `Sidekiq::Limiter::OverLimit` exception when the rate limit is exceeded https://github.com/mperham/sidekiq/wiki/Ent-Rate-Limiting

It has middleware that catches that exception and re-queues the job rather then treating that exception as a true failure.  Depending on the ordering of middleware this gem might either count this as a failure or a success. Tracking this metric separately as neither a success nor failure seems ideal. 