### PR TITLE
Allow sidekiq-prometheus to work with prometheus-client version > 2

### DIFF
--- a/sidekiq_prometheus.gemspec
+++ b/sidekiq_prometheus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.58.0'
 
-  spec.add_runtime_dependency 'prometheus-client', '~> 4.0'
+  spec.add_runtime_dependency 'prometheus-client', '>= 2.0'
   spec.add_runtime_dependency 'rack'
   spec.add_runtime_dependency 'sidekiq', '> 5.1'
   spec.add_runtime_dependency 'webrick'

--- a/sidekiq_prometheus.gemspec
+++ b/sidekiq_prometheus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.58.0'
 
-  spec.add_runtime_dependency 'prometheus-client', '~> 2.0'
+  spec.add_runtime_dependency 'prometheus-client', '~> 4.0'
   spec.add_runtime_dependency 'rack'
   spec.add_runtime_dependency 'sidekiq', '> 5.1'
   spec.add_runtime_dependency 'webrick'


### PR DESCRIPTION
We use this gem with prometheus-client v4 without any issues for the last few months, I think it should be fine to relax this requirement.