### PR TITLE
Fixes Newer Sidekiq-Enterprise versions that have a Senate.leader? issue with Sidekiq Prometheus 1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ end
 * `periodic_metrics_enabled`: Boolean that determines whether to run the periodic metrics reporter. `PeriodicMetrics` runs a separate thread that reports on global metrics (if enabled) as well worker GC stats (if enabled). It reports metrics on the interval defined by `periodic_reporting_interval`. Defaults to `true`.
 * `periodic_reporting_interval`: interval in seconds for reporting periodic metrics. Default: `30`
 * `metrics_server_enabled`: Boolean that determines whether to run the rack server. Defaults to `true`
-* `metrics_server_logging_enabled`: Boolean that determines if the metrics server will log access logs. Defaults to `true`
+* `metrics_server_logger_enabled`: Boolean that determines if the metrics server will log access logs. Defaults to `true`
 * `metrics_host`: Host on which the rack server will listen. Defaults to
   `localhost`
 * `metrics_port`: Port on which the rack server will listen. Defaults to `9359`

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -195,8 +195,8 @@ module SidekiqPrometheus
       end
 
       if periodic_metrics_enabled?
-        config.on(:startup)  { SidekiqPrometheus::PeriodicMetrics.reporter.start }
-        config.on(:shutdown) { SidekiqPrometheus::PeriodicMetrics.reporter.stop }
+        config.on(:startup)  { SidekiqPrometheus::PeriodicMetrics.reporter(config).start }
+        config.on(:shutdown) { SidekiqPrometheus::PeriodicMetrics.reporter(config).stop }
       end
 
       if metrics_server_enabled?

--- a/lib/sidekiq_prometheus/periodic_metrics.rb
+++ b/lib/sidekiq_prometheus/periodic_metrics.rb
@@ -10,10 +10,13 @@
 # @see https://github.com/mperham/sidekiq/wiki/Ent-Leader-Election
 # @see https://github.com/mperham/sidekiq/blob/main/lib/sidekiq/api.rb
 
-require 'sidekiq/component'
+begin
+  require 'sidekiq/component'
+rescue LoadError
+end
 
 class SidekiqPrometheus::PeriodicMetrics
-  include Sidekiq::Component
+  include Sidekiq::Component if defined? Sidekiq::Component
 
   # @return [Boolean] When +true+ will stop the reporting loop.
   attr_accessor :done

--- a/lib/sidekiq_prometheus/periodic_metrics.rb
+++ b/lib/sidekiq_prometheus/periodic_metrics.rb
@@ -10,6 +10,8 @@
 # @see https://github.com/mperham/sidekiq/wiki/Ent-Leader-Election
 # @see https://github.com/mperham/sidekiq/blob/main/lib/sidekiq/api.rb
 
+require 'sidekiq/component'
+
 class SidekiqPrometheus::PeriodicMetrics
   include Sidekiq::Component
 

--- a/sidekiq_prometheus.gemspec
+++ b/sidekiq_prometheus.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'prometheus-client', '>= 2.0'
   spec.add_runtime_dependency 'rack'
-  spec.add_runtime_dependency 'sidekiq', '> 5.1'
+  spec.add_runtime_dependency 'sidekiq', '> 5.1', '< 7.0'
   spec.add_runtime_dependency 'webrick'
 end


### PR DESCRIPTION
Some but not all metrics stopped working with the 1.8.1 release.  Specifically `report_global_metrics` and `reported_redis_metrics` in PeriodicMetrics have stopped working when combined with the latest versions of sidekiq-enterprise due to a bug in my previous sidekiq-enterprise related update which was accepted and released as 1.8.1.  

The conditional evaluates to false for each of these lines
```
        report_global_metrics if SidekiqPrometheus.global_metrics_enabled? && senate.leader?
        report_redis_metrics if SidekiqPrometheus.global_metrics_enabled? && senate.leader?
```        
if one is using the latest versions of sidekiq-enterprise because `senate.leader?` returns false with the current `Sidekiq::Senate.new(Sidekiq)` code.

This PR fixes that Sidekiq Senate issue. The Senate object is instantiated inside Sidekiq and we can not instantiate a new one in sidekiq-prometheus code, even though the Redis leader key that this process generates matches what we expect for the leader, the object is still not the right one.  

The fix follows the example from the Sidekiq wiki for [Running Code on the Leader](https://github.com/mperham/sidekiq/wiki/Ent-Leader-Election#running-code-on-the-leader) by including `Sidekiq::Component` which includes a `leader?` method that requires us to pass in the Sidekiq config so that it can access the correct value.