### PR TITLE
Track leader state so that can unregister when demoted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 3.2
   - 3.1
   - 3.0
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: ruby
 rvm:
+  - 3.2
+  - 3.1
   - 3.0
   - 2.7
-  - 2.6
-  - 2.5
 before_install: gem install bundler -v 2.2.15

--- a/Rakefile
+++ b/Rakefile
@@ -2,18 +2,11 @@
 
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require "standard/rake"
 
 RSpec::Core::RakeTask.new(:spec)
 
-begin
-  require "rubocop/rake_task"
-  RuboCop::RakeTask.new(:rubocop) do |task|
-    task.options = ["-c.rubocop.yml"]
-  end
-rescue LoadError
-end
-
 task default: %w[
-  rubocop
+  standard
   spec
 ]

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -178,7 +178,6 @@ module SidekiqPrometheus
     SidekiqPrometheus::Metrics.register_sidekiq_job_metrics
     SidekiqPrometheus::Metrics.register_sidekiq_gc_metric if gc_metrics_enabled?
     SidekiqPrometheus::Metrics.register_sidekiq_worker_gc_metrics if gc_metrics_enabled? && periodic_metrics_enabled?
-    SidekiqPrometheus::Metrics.register_sidekiq_global_metrics if global_metrics_enabled? && periodic_metrics_enabled?
     register_custom_metrics
 
     sidekiq_setup

--- a/lib/sidekiq_prometheus/metrics.rb
+++ b/lib/sidekiq_prometheus/metrics.rb
@@ -131,6 +131,16 @@ module SidekiqPrometheus::Metrics
     end
   end
 
+  def unregister_sidekiq_global_metrics
+    unregister_metrics SIDEKIQ_GLOBAL_METRICS
+  end
+
+  def unregister_metrics(metrics)
+    metrics.each do |metric|
+      unregister(name: metric[:name])
+    end
+  end
+
   ##
   # Fetch a metric from the registry
   # @param name [Symbol] name of metric to fetch

--- a/spec/sidekiq_prometheus/metrics_spec.rb
+++ b/spec/sidekiq_prometheus/metrics_spec.rb
@@ -101,4 +101,16 @@ RSpec.describe SidekiqPrometheus::Metrics do
       end
     end
   end
+
+  describe "unregister_sidekiq_global_metrics" do
+    it "unregisters global metrics" do
+      described_class.register_sidekiq_global_metrics
+
+      described_class.unregister_sidekiq_global_metrics
+
+      described_class::SIDEKIQ_GLOBAL_METRICS.each do |metric|
+        expect(described_class.get(metric[:name])).to be nil
+      end
+    end
+  end
 end

--- a/spec/sidekiq_prometheus/periodic_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/periodic_metrics_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe SidekiqPrometheus::PeriodicMetrics do
       senate_leader = true
       r.handle_leader_state(senate_leader)
 
-      #expect(r.leader).to be true
+      # expect(r.leader).to be true
       expect(SidekiqPrometheus::Metrics).not_to have_received(:register_sidekiq_global_metrics)
       expect(SidekiqPrometheus::Metrics).not_to have_received(:unregister_sidekiq_global_metrics)
     end

--- a/spec/sidekiq_prometheus_spec.rb
+++ b/spec/sidekiq_prometheus_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe SidekiqPrometheus do
         SidekiqPrometheus::Metrics.register_sidekiq_job_metrics
         thread = described_class.metrics_server
 
-        sleep 0.5
+        sleep 1
 
         http = Net::HTTP.new(SidekiqPrometheus.metrics_host, SidekiqPrometheus.metrics_port)
         res = http.request(Net::HTTP::Get.new("/metrics"))


### PR DESCRIPTION
Adds new instance variable on the periodic reporter to track of the senate leader from sidekiq. With this we can determine the the instance was demoted and unregister the global metrics so that they don't continue to be scraped.

There is still he possibility for two instances to report the global metrics if the new leader and the old leader are scraped before the old leader has unregistered the metrics. It could happen the other way where the old leader has unregistered and is scraped before the new leader has registered and reported metrics.

This could be fixed by using redis pubsub to signal to all instances when a leader change has happened and refresh state. I think this code will work in most cases especially if the reporting interval is lowered to match the scrape interval.

fixes https://github.com/fastly/sidekiq-prometheus/issues/35 and https://github.com/fastly/sidekiq-prometheus/issues/24