### PR TITLE
Add support for Rack 2 and 3

### DIFF
--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -219,10 +219,10 @@ module SidekiqPrometheus
   def webrick_handler
     @_webrick_handler ||= begin
       begin
-        require 'rackup'
+        require "rackup"
       rescue LoadError # rubocop:disable Lint/SuppressedException
       end
-    
+
       defined?(Rackup::Handler::WEBrick) ? Rackup::Handler::WEBrick : Rack::Handler::WEBrick
     end
   end
@@ -238,7 +238,7 @@ module SidekiqPrometheus
     }
 
     unless metrics_server_logger_enabled?
-      opts[:Logger] = WEBrick::Log.new("/dev/null")
+      opts[:Logger] = WEBrick::Log.new(File::NULL)
       opts[:AccessLog] = []
     end
 

--- a/sidekiq_prometheus.gemspec
+++ b/sidekiq_prometheus.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "standard"
 
   spec.add_runtime_dependency "prometheus-client", ">= 2.0"
-  spec.add_runtime_dependency "rack", "< 3.0"
+  spec.add_runtime_dependency "rack", "> 2.0", "~> 3.0"
   spec.add_runtime_dependency "redis"
   spec.add_runtime_dependency "sidekiq", "> 5.1"
   spec.add_runtime_dependency "webrick"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,5 +26,5 @@ def silence
 end
 
 Sidekiq.configure_server do |cfg|
-  cfg.logger = Logger.new("/dev/null")
+  cfg.logger = Logger.new(File::NULL)
 end


### PR DESCRIPTION
This is a new version of #45 that includes fixes for standardrb so that CI passes.

Quoting the original PR:

This PR adds support for booting the metrics server under Rack 3.

Without this patch, I was unable to boot the metrics_server under Rails 7.2+ with Rack 3 due to a change in the Rack::Handler::WEBrick module. It has been moved to the rackup gem and namespace.