### PR TITLE
Require Rack ~> 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
-
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
+        gemfile: [ sidekiq_6, sidekiq_7 ]
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}.gemfile
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['2.7', '3.1', '3.2', '3.3', '3.4']
         gemfile: [ sidekiq_6, sidekiq_7 ]
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}.gemfile

--- a/lib/sidekiq_prometheus.rb
+++ b/lib/sidekiq_prometheus.rb
@@ -2,6 +2,7 @@
 
 require "benchmark"
 require "rack"
+require "rackup"
 require "prometheus/client"
 require "prometheus/middleware/exporter"
 require "sidekiq"
@@ -225,12 +226,12 @@ module SidekiqPrometheus
     }
 
     unless metrics_server_logger_enabled?
-      opts[:Logger] = WEBrick::Log.new("/dev/null")
+      opts[:Logger] = WEBrick::Log.new(File::NULL)
       opts[:AccessLog] = []
     end
 
     @_metrics_server ||= Thread.new do
-      Rack::Handler::WEBrick.run(
+      Rackup::Handler::WEBrick.run(
         Rack::Builder.new {
           use Prometheus::Middleware::Exporter, registry: SidekiqPrometheus.registry
           run ->(_) { [301, {"Location" => "/metrics"}, []] }

--- a/lib/sidekiq_prometheus/version.rb
+++ b/lib/sidekiq_prometheus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqPrometheus
-  VERSION = "2.0.1"
+  VERSION = "3.0.0"
 end

--- a/sidekiq_prometheus.gemspec
+++ b/sidekiq_prometheus.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "standard"
 
   spec.add_runtime_dependency "prometheus-client", ">= 2.0"
-  spec.add_runtime_dependency "rack", "< 3.0"
+  spec.add_runtime_dependency "rack", "~> 3.0"
+  spec.add_runtime_dependency "rackup", ">2.0"
   spec.add_runtime_dependency "redis"
   spec.add_runtime_dependency "sidekiq", "> 5.1"
   spec.add_runtime_dependency "webrick"

--- a/spec/sidekiq_prometheus/periodic_metrics_spec.rb
+++ b/spec/sidekiq_prometheus/periodic_metrics_spec.rb
@@ -35,11 +35,13 @@ RSpec.describe SidekiqPrometheus::PeriodicMetrics do
 
   describe "#start" do
     it "starts a reporter in a new thread" do
-      allow(Thread).to receive(:new)
+      silence do
+        allow(Thread).to receive(:new)
 
-      reporter.start
+        reporter.start
 
-      expect(Thread).to have_received(:new) { |&block| expect(block).to be_kind_of(Proc) }
+        expect(Thread).to have_received(:new) { |&block| expect(block).to be_kind_of(Proc) }
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,5 +26,5 @@ def silence
 end
 
 Sidekiq.configure_server do |cfg|
-  cfg.logger = Logger.new("/dev/null")
+  cfg.logger = Logger.new(File::NULL)
 end


### PR DESCRIPTION
* Updates dependencies to require rack ~> 3.0 and rackup > 2.0. **this is a breaking change**
* Fixes for standardrb linting
* Test against supported rubies and against sidekiq 6 and 7
* Version bump to 3.0.0
